### PR TITLE
feature: obfs4proxy support

### DIFF
--- a/doc/setup-obfs4.md
+++ b/doc/setup-obfs4.md
@@ -1,0 +1,54 @@
+### OBFS4 Proxy Setup
+
+To run the Wallet with obfs4 enabled one must install the *obfs4proxy* [package](https://launchpad.net/ubuntu/+source/obfs4proxy) first. Also don't forget **to close your Wallet or daemon** before starting to change configuration files below.
+
+#### Install obfs4proxy (Ubuntu, Debian)
+
+```shell
+sudo apt-get install obfs4proxy
+```
+
+#### Find available Bridges
+
+Visit this [website](https://bridges.torproject.org/bridges) to get a list of Bridges which you'll insert into the *torrc* file under your *datadir*.
+
+#### Edit tor configuration file
+
+Your *datadir* depends on the OS you're using. Possible locations of the *torrc* are:
+
+* Windows - %APPDATA%/DeepOnion/tor
+* Linux - ~/.DeepOnion/tor
+* Mac -  ~/Library/Application Support/DeepOnion/tor
+
+Open *torrc* and remove any lines that begin with *Bridge*. Now add the bridges you got from the above website with the keyword *Bridge* prepended.
+
+Here's an example:
+
+```
+Bridge 80.92.79.70:80 312D64274C29156005843EECB19C6865FA3CC10C
+Bridge 52.19.30.6:8443 FC5D6558344479BBB10E8638CC8CEB8BA6E32DAD
+Bridge 178.63.28.14:443 88CB40E536DD6F6775626E6A3BCC5D9C0B7BAFEA
+```
+
+Start your wallet, or daemon if running *headless*, and trace your tor's *logfile* with:
+
+```
+tail -f YOUR_DATADIR/tor/tor.log
+```
+
+You should see entries similar to those below:
+
+```
+Jan 28 20:31:14.000 [notice] Bootstrapped 0%: Starting
+Jan 28 20:31:15.000 [notice] Starting with guard context "bridges"
+Jan 28 20:31:15.000 [notice] new bridge descriptor 'piratepartei0' (cached): $312D64274C29156005843EECB19C6865FA3CC10C~piratepartei0 at 80.92.79.70
+Jan 28 20:31:15.000 [notice] Bridge 'dax' has both an IPv4 and an IPv6 address.  Will prefer using its IPv4 address (178.63.28.14:443) based on the configured Br
+idge address.
+Jan 28 20:31:15.000 [notice] new bridge descriptor 'dax' (cached): $88CB40E536DD6F6775626E6A3BCC5D9C0B7BAFEA~dax at 178.63.28.14
+Jan 28 20:31:15.000 [notice] Bootstrapped 80%: Connecting to the Tor network
+Jan 28 20:31:15.000 [notice] Bootstrapped 85%: Finishing handshake with first hop
+Jan 28 20:31:16.000 [notice] Bootstrapped 90%: Establishing a Tor circuit
+Jan 28 20:31:16.000 [notice] Tor has successfully opened a circuit. Looks like client functionality is working.
+Jan 28 20:31:16.000 [notice] Bootstrapped 100%: Done
+
+```

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -602,63 +602,6 @@ bool AppInit2()
                 SetLimited(net);
         }
     }
-
-    /*
-    if (mapArgs.count("-onlynet")) {
-        std::set<enum Network> nets;
-        BOOST_FOREACH(std::string snet, mapMultiArgs["-onlynet"]) {
-            enum Network net = ParseNetwork(snet);
-            if (net == NET_UNROUTABLE)
-                return InitError(strprintf(_("Unknown network specified in -onlynet: '%s'"), snet.c_str()));
-            nets.insert(net);
-        }
-        for (int n = 0; n < NET_MAX; n++) {
-            enum Network net = (enum Network)n;
-            if (!nets.count(net))
-                SetLimited(net);
-        }
-    }
-#if defined(USE_IPV6)
-#if ! USE_IPV6
-    else
-        SetLimited(NET_IPV6);
-#endif
-#endif
-
-    CService addrProxy;
-    bool fProxy = false;
-    if (mapArgs.count("-proxy")) {
-        addrProxy = CService(mapArgs["-proxy"], 9050);
-        if (!addrProxy.IsValid())
-            return InitError(strprintf(_("Invalid -proxy address: '%s'"), mapArgs["-proxy"].c_str()));
-
-        if (!IsLimited(NET_IPV4))
-            SetProxy(NET_IPV4, addrProxy, nSocksVersion);
-        if (nSocksVersion > 4) {
-#ifdef USE_IPV6
-            if (!IsLimited(NET_IPV6))
-                SetProxy(NET_IPV6, addrProxy, nSocksVersion);
-#endif
-            SetNameProxy(addrProxy, nSocksVersion);
-        }
-        fProxy = true;
-    }
-
-    // -tor can override normal proxy, -notor disables tor entirely
-    if (!(mapArgs.count("-tor") && mapArgs["-tor"] == "0") && (fProxy || mapArgs.count("-tor"))) {
-    CService addrOnion;
-
-        if (!mapArgs.count("-tor"))
-            addrOnion = addrProxy;
-        else
-        addrOnion = CService(mapArgs["-tor"], onion_port);
-
-        if (!addrOnion.IsValid())
-            return InitError(strprintf(_("Invalid -tor address: '%s'"), mapArgs["-tor"].c_str()));
-    } else {
-        addrOnion = CService("127.0.0.1", onion_port);
-    }
-*/
     
     CService addrOnion;
     if (mapArgs.count("-tor") && mapArgs["-tor"] != "0") {
@@ -681,44 +624,7 @@ bool AppInit2()
     fUseUPnP = GetBoolArg("-upnp", USE_UPNP);
 #endif
 
-    bool fBound = false;
-    /*
-    if (!fNoListen)
-    {
-        std::string strError;
-        if (mapArgs.count("-bind")) {
-            BOOST_FOREACH(std::string strBind, mapMultiArgs["-bind"]) {
-                CService addrBind;
-                if (!Lookup(strBind.c_str(), addrBind, GetListenPort(), false))
-                    return InitError(strprintf(_("Cannot resolve -bind address: '%s'"), strBind.c_str()));
-                fBound |= Bind(addrBind);
-            }
-        } else {
-            struct in_addr inaddr_any;
-            inaddr_any.s_addr = INADDR_ANY;
-#ifdef USE_IPV6
-            if (!IsLimited(NET_IPV6))
-                fBound |= Bind(CService(in6addr_any, GetListenPort()), false);
-#endif
-            if (!IsLimited(NET_IPV4))
-                fBound |= Bind(CService(inaddr_any, GetListenPort()), !fBound);
-            }
-
-            if (isfTor == 1)
-            {
-                CService addrBind;
-
-                if (!Lookup("127.0.0.1", addrBind, GetListenPort(), false))
-                    return InitError(strprintf(_("Cannot resolve binding address: '%s'"), "127.0.0.1"));
-
-                fBound |= Bind(addrBind);
-            }
-
-        if (!fBound)
-            return InitError(_("Failed to listen on any port. Use -listen=0 if you want this."));
-    }
-	*/
-    
+    bool fBound = false; 
     // Tor implementation
     std::string strError;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -196,11 +196,6 @@ uint256 GetRandHash()
     return hash;
 }
 
-
-
-
-
-
 static FILE* fileout = NULL;
 
 inline int OutputDebugStringF(const char* pszFormat, ...)

--- a/src/util.h
+++ b/src/util.h
@@ -129,12 +129,7 @@ inline void MilliSleep(int64_t n)
 #define ATTR_WARN_PRINTF(X,Y)
 #endif
 
-
-
-
-
-
-
+#define LogPrintf printf
 
 extern std::map<std::string, std::string> mapArgs;
 extern std::map<std::string, std::vector<std::string> > mapMultiArgs;


### PR DESCRIPTION
* Support for **obfs4proxy** added (obfs4proxy package must be installed and **torrc** under *DATADIR/tor/* must contain bridge entries which can be found here: https://bridges.torproject.org/bridges)
* Removed unrelated but redundant code from init.cpp
* Added LogPrintf (currently only a #define)
* Added setup doc for obfs4proxy