### PR TITLE
fix: pass c-string to log function

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -649,7 +649,7 @@ void ThreadTorNet2(void* parg) {
     argv.push_back("17570");
 
     if (clientTransportPlugin) {
-      LogPrintf("Using external obfs4proxy as ClientTransportPlugin.\nSpecify bridges in %s\n", torrc);
+      LogPrintf("Using external obfs4proxy as ClientTransportPlugin.\nSpecify bridges in %s\n", torrc.c_str());
       argv.push_back("--ClientTransportPlugin");
       argv.push_back(*clientTransportPlugin);
       argv.push_back("--UseBridges");


### PR DESCRIPTION
Fixes the problem with non-trivially copyable objects.