### PR TITLE
added bsdmainutils

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -16,7 +16,7 @@ First get the dependencies:
 
     apt-get update
     apt-get upgrade
-    apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libboost-all-dev
+    apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libboost-all-dev bsdmainutils
     apt-get install libqrencode-dev libminiupnpc-dev libevent-dev libcap-dev libseccomp-dev git
 
 


### PR DESCRIPTION
We have missed to include this package. It contains **hexdump** which is needed in certain configurations.
Got the info in [our forums](https://deeponion.org/community/posts/441468/report) from User **[Youngwebs](https://deeponion.org/community/members/youngwebs.444/)**