### PR TITLE
Minor edit/addition for transparency; (line 5).

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
Simply added back two items included in original 'Contributor Covenant v.1.4' (see attribution) after reviewing both that and slightly modified DeepOnion adopted version. Most had been left as is (by original contributor, [Wh0Kn0ws](https://github.com/Wh0Kn0ws) with the exception of a re-written line in 'Enforcement' section (line 37), which I agree is better than that of Contributor Covenant's version.

Rational: If not broke don't fix it. There is no reason to allow abusive or non-welcoming environment for anyone (per pledge) including, not excluding, those that maybe from higher or lower educational or socio-economic backgrounds. It works respectfully both ways.