### PR TITLE
Added categories to vRPCCommands table and added those categories to help output

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -25,6 +25,7 @@
 #include <boost/shared_ptr.hpp>
 #include <list>
 
+
 #define printf OutputDebugStringF
 
 using namespace std;
@@ -164,11 +165,17 @@ vector<unsigned char> ParseHexO(const Object& o, string strKey)
 string CRPCTable::help(string strCommand) const
 {
     string strRet;
+    string category;
     set<rpcfn_type> setDone;
+    vector<pair<string, const CRPCCommand*> > vCommands;
+
     for (map<string, const CRPCCommand*>::const_iterator mi = mapCommands.begin(); mi != mapCommands.end(); ++mi)
-    {
-        const CRPCCommand *pcmd = mi->second;
-        string strMethod = mi->first;
+        vCommands.push_back(make_pair(mi->second->category + mi->first, mi->second));
+    sort(vCommands.begin(), vCommands.end());
+
+    BOOST_FOREACH (const PAIRTYPE(string, const CRPCCommand*) & command, vCommands) {
+        const CRPCCommand* pcmd = command.second;
+        string strMethod = pcmd->name;
         // We already filter duplicates, but these deprecated screw up the sort order
         if (strMethod.find("label") != string::npos)
             continue;
@@ -185,9 +192,19 @@ string CRPCTable::help(string strCommand) const
         {
             // Help text is returned in an exception
             string strHelp = string(e.what());
-            if (strCommand == "")
+            if (strCommand == "") {
                 if (strHelp.find('\n') != string::npos)
                     strHelp = strHelp.substr(0, strHelp.find('\n'));
+
+                if (category != pcmd->category) {
+                    if (!category.empty())
+                        strRet += "\n";
+                    category = pcmd->category;
+                    string firstLetter = category.substr(0, 1);
+                    boost::to_upper(firstLetter);
+                    strRet += "== " + firstLetter + category.substr(1) + " ==\n";
+                }
+            }
             strRet += strHelp + "\n";
         }
     }
@@ -234,101 +251,116 @@ Value stop(const Array& params, bool fHelp)
 
 static const CRPCCommand vRPCCommands[] =
     {
-        //  name                      function                 safemd  unlocked
-        //  ------------------------  -----------------------  ------  --------
-        {"help", &help, true, true},
-        {"stop", &stop, true, true},
-        {"getbestblockhash", &getbestblockhash, true, false},
-        {"getblockcount", &getblockcount, true, false},
-        {"getconnectioncount", &getconnectioncount, true, false},
-        {"getpeerinfo", &getpeerinfo, true, false},
-        {"getdifficulty", &getdifficulty, true, false},
-        {"getnetworkhashps", &getnetworkhashps, true, false},
-        {"getnettotals", &getnettotals, true, false},
-        {"getinfo", &getinfo, true, false},
-        {"getsubsidy", &getsubsidy, true, false},
-        {"getmininginfo", &getmininginfo, true, false},
-        {"getstakinginfo", &getstakinginfo, true, false},
-        {"getnewaddress", &getnewaddress, true, false},
-        {"getnewpubkey", &getnewpubkey, true, false},
-        {"getaccountaddress", &getaccountaddress, true, false},
-        {"setaccount", &setaccount, true, false},
-        {"getaccount", &getaccount, false, false},
-        {"getaddressesbyaccount", &getaddressesbyaccount, true, false},
-        {"sendtoaddress", &sendtoaddress, false, false},
-        {"getreceivedbyaddress", &getreceivedbyaddress, false, false},
-        {"getreceivedbyaccount", &getreceivedbyaccount, false, false},
-        {"listreceivedbyaddress", &listreceivedbyaddress, false, false},
-        {"listreceivedbyaccount", &listreceivedbyaccount, false, false},
-        {"backupwallet", &backupwallet, true, false},
-        {"keypoolrefill", &keypoolrefill, true, false},
-        {"walletpassphrase", &walletpassphrase, true, false},
-        {"walletpassphrasechange", &walletpassphrasechange, false, false},
-        {"walletlock", &walletlock, true, false},
-        {"encryptwallet", &encryptwallet, false, false},
-        {"validateaddress", &validateaddress, true, false},
-        {"validatepubkey", &validatepubkey, true, false},
-        {"getbalance", &getbalance, false, false},
-        {"move", &movecmd, false, false},
-        {"sendfrom", &sendfrom, false, false},
-        {"sendmany", &sendmany, false, false},
-        {"addmultisigaddress", &addmultisigaddress, false, false},
-        {"addredeemscript", &addredeemscript, false, false},
-        {"getrawmempool", &getrawmempool, true, false},
-        {"getblock", &getblock, false, false},
-        {"getblockbynumber", &getblockbynumber, false, false},
-        {"getblockhash", &getblockhash, false, false},
-        {"gettransaction", &gettransaction, false, false},
-        {"listtransactions", &listtransactions, false, false},
-        {"listaddressgroupings", &listaddressgroupings, false, false},
-        {"signmessage", &signmessage, false, false},
-        {"verifymessage", &verifymessage, false, false},
-        {"getwork", &getwork, true, false},
-        {"getworkex", &getworkex, true, false},
-        {"listaccounts", &listaccounts, false, false},
-        {"settxfee", &settxfee, false, false},
-        {"getblocktemplate", &getblocktemplate, true, false},
-        {"submitblock", &submitblock, false, false},
-        {"listsinceblock", &listsinceblock, false, false},
-        {"dumpprivkey", &dumpprivkey, false, false},
-        {"dumpwallet", &dumpwallet, true, false},
-        {"importwallet", &importwallet, false, false},
-        {"importprivkey", &importprivkey, false, false},
-        {"listunspent", &listunspent, false, false},
-        {"getrawtransaction", &getrawtransaction, false, false},
-        {"createrawtransaction", &createrawtransaction, false, false},
-        {"decoderawtransaction", &decoderawtransaction, false, false},
-        {"decodescript", &decodescript, false, false},
-        {"signrawtransaction", &signrawtransaction, false, false},
-        {"sendrawtransaction", &sendrawtransaction, false, false},
-        {"getcheckpoint", &getcheckpoint, true, false},
-        {"reservebalance", &reservebalance, false, true},
-        {"checkwallet", &checkwallet, false, true},
-        {"repairwallet", &repairwallet, false, true},
-        {"resendtx", &resendtx, false, true},
-        {"makekeypair", &makekeypair, false, true},
-        {"sendalert", &sendalert, false, false},
+        //  category          name                     function                  safemd  unlocked
+        //  ----------------  -----------------------  ------------------------  ------  --------
 
-        {"getnewstealthaddress", &getnewstealthaddress, false, false},
-        {"liststealthaddresses", &liststealthaddresses, false, false},
-        {"importstealthaddress", &importstealthaddress, false, false},
-        {"sendtostealthaddress", &sendtostealthaddress, false, false},
-        {"scanforalltxns", &scanforalltxns, false, false},
-        {"scanforstealthtxns", &scanforstealthtxns, false, false},
+        /* Overall control/query calls */
+        {"control",           "help",                   &help,                   true,   true },
+        {"control",           "stop",                   &stop,                   true,   true },
+        {"control",           "getinfo",                &getinfo,                true,   false},
 
-        {"smsgenable", &smsgenable, false, false},
-        {"smsgdisable", &smsgdisable, false, false},
-        {"smsglocalkeys", &smsglocalkeys, false, false},
-        {"smsgoptions", &smsgoptions, false, false},
-        {"smsgscanchain", &smsgscanchain, false, false},
-        {"smsgscanbuckets", &smsgscanbuckets, false, false},
-        {"smsgaddkey", &smsgaddkey, false, false},
-        {"smsggetpubkey", &smsggetpubkey, false, false},
-        {"smsgsend", &smsgsend, false, false},
-        {"smsgsendanon", &smsgsendanon, false, false},
-        {"smsginbox", &smsginbox, false, false},
-        {"smsgoutbox", &smsgoutbox, false, false},
-        {"smsgbuckets", &smsgbuckets, false, false},
+        /* P2P networking */
+        {"network",           "getconnectioncount",     &getconnectioncount,     true,   false},
+        {"network",           "getnettotals",           &getnettotals,           true,   false},
+        {"network",           "getpeerinfo",            &getpeerinfo,            true,   false},
+        {"network",           "sendalert",              &sendalert,              false,  false},
+
+        /* Block chain mining and UTXO */
+        {"blockchain",        "getbestblockhash",       &getbestblockhash,       true,   false},
+        {"blockchain",        "getblockcount",          &getblockcount,          true,   false},
+        {"blockchain",        "getblock",               &getblock,               false,  false},
+        {"blockchain",        "getblockhash",           &getblockhash,           false,  false},
+        {"blockchain",        "getblockbynumber",       &getblockbynumber,       false,  false},
+        {"blockchain",        "getcheckpoint",          &getcheckpoint,          true,   false},
+        {"blockchain",        "getblocktemplate",       &getblocktemplate,       true,   false},
+        {"blockchain",        "getdifficulty",          &getdifficulty,          true,   false},
+        {"blockchain",        "getmininginfo",          &getmininginfo,          true,   false},
+        {"blockchain",        "getnetworkhashps",       &getnetworkhashps,       true,   false},
+        {"blockchain",        "getrawmempool",          &getrawmempool,          true,   false},
+        {"blockchain",        "getstakinginfo",         &getstakinginfo,         true,   false},
+        {"blockchain",        "getsubsidy",             &getsubsidy,             true,   false},
+        {"blockchain",        "getwork",                &getwork,                true,   false},
+        {"blockchain",        "getworkex",              &getworkex,              true,   false},
+        {"blockchain",        "settxfee",               &settxfee,               false,  false},
+        {"blockchain",        "submitblock",            &submitblock,            false,  false},
+        {"blockchain",        "reservebalance",         &reservebalance,         false,  true },      
+
+        /* Wallet */
+        {"wallet",            "addmultisigaddress",     &addmultisigaddress,     false,  false},
+        {"wallet",            "addredeemscript",        &addredeemscript,        false,  false},
+        {"wallet",            "backupwallet",           &backupwallet,           true,   false},
+        {"wallet",            "checkwallet",            &checkwallet,            false,  true },
+        {"wallet",            "dumpprivkey",            &dumpprivkey,            false,  false},
+        {"wallet",            "dumpwallet",             &dumpwallet,             true,   false},
+        {"wallet",            "encryptwallet",          &encryptwallet,          false,  false},
+        {"wallet",            "getaccountaddress",      &getaccountaddress,      true,   false},
+        {"wallet",            "getaccount",             &getaccount,             false,  false},
+        {"wallet",            "getaddressesbyaccount",  &getaddressesbyaccount,  true,   false},
+        {"wallet",            "getbalance",             &getbalance,             false,  false},
+        {"wallet",            "getnewaddress",          &getnewaddress,          true,   false},
+        {"wallet",            "getnewpubkey",           &getnewpubkey,           true,   false},
+        {"wallet",            "getreceivedbyaccount",   &getreceivedbyaccount,   false,  false},
+        {"wallet",            "getreceivedbyaddress",   &getreceivedbyaddress,   false,  false},
+        {"wallet",            "gettransaction",         &gettransaction,         false,  false},
+        {"wallet",            "importprivkey",          &importprivkey,          false,  false},
+        {"wallet",            "importwallet",           &importwallet,           false,  false},
+        {"wallet",            "keypoolrefill",          &keypoolrefill,          true,   false},
+        {"wallet",            "listaccounts",           &listaccounts,           false,  false},
+        {"wallet",            "listaddressgroupings",   &listaddressgroupings,   false,  false},
+        {"wallet",            "listreceivedbyaccount",  &listreceivedbyaccount,  false,  false},
+        {"wallet",            "listreceivedbyaddress",  &listreceivedbyaddress,  false,  false},
+        {"wallet",            "listsinceblock",         &listsinceblock,         false,  false},
+        {"wallet",            "listtransactions",       &listtransactions,       false,  false},
+        {"wallet",            "listunspent",            &listunspent,            false,  false},
+        {"wallet",            "move",                   &movecmd,                false,  false},
+        {"wallet",            "repairwallet",           &repairwallet,           false,  true },
+        {"wallet",            "sendfrom",               &sendfrom,               false,  false},
+        {"wallet",            "sendmany",               &sendmany,               false,  false},
+        {"wallet",            "sendtoaddress",          &sendtoaddress,          false,  false},
+        {"wallet",            "setaccount",             &setaccount,             true,   false},
+        {"wallet",            "resendtx",               &resendtx,               false,  true },
+        {"wallet",            "walletlock",             &walletlock,             true,   false},
+        {"wallet",            "walletpassphrasechange", &walletpassphrasechange, false,  false},
+        {"wallet",            "walletpassphrase",       &walletpassphrase,       true,   false},      
+        
+        /* Utility functions */
+        {"util",              "makekeypair",            &makekeypair,            false,  true },
+        {"util",              "signmessage",            &signmessage,            false,  false},
+        {"util",              "verifymessage",          &verifymessage,          false,  false},
+        {"util",              "validateaddress",        &validateaddress,        true,   false},
+        {"util",              "validatepubkey",         &validatepubkey,         true,   false},
+
+        /* Raw transactions */
+        {"rawtransactions",   "createrawtransaction",   &createrawtransaction,   false,  false},
+        {"rawtransactions",   "decoderawtransaction",   &decoderawtransaction,   false,  false},
+        {"rawtransactions",   "decodescript",           &decodescript,           false,  false},
+        {"rawtransactions",   "getrawtransaction",      &getrawtransaction,      false,  false},
+        {"rawtransactions",   "listunspent",            &listunspent,            false,  false},
+        {"rawtransactions",   "sendrawtransaction",     &sendrawtransaction,     false,  false},
+        {"rawtransactions",   "signrawtransaction",     &signrawtransaction,     false,  false},    
+
+        /* Stealth Addresses */
+        {"stealth",           "getnewstealthaddress",   &getnewstealthaddress,   false,  false},
+        {"stealth",           "liststealthaddresses",   &liststealthaddresses,   false,  false},
+        {"stealth",           "importstealthaddress",   &importstealthaddress,   false,  false},
+        {"stealth",           "sendtostealthaddress",   &sendtostealthaddress,   false,  false},
+        {"stealth",           "scanforalltxns",         &scanforalltxns,         false,  false},
+        {"stealth",           "scanforstealthtxns",     &scanforstealthtxns,     false,  false},
+        
+        /* Messages */
+        {"messages",          "smsgenable",             &smsgenable,             false,  false},
+        {"messages",          "smsgdisable",            &smsgdisable,            false,  false},
+        {"messages",          "smsglocalkeys",          &smsglocalkeys,          false,  false},
+        {"messages",          "smsgoptions",            &smsgoptions,            false,  false},
+        {"messages",          "smsgscanchain",          &smsgscanchain,          false,  false},
+        {"messages",          "smsgscanbuckets",        &smsgscanbuckets,        false,  false},
+        {"messages",          "smsgaddkey",             &smsgaddkey,             false,  false},
+        {"messages",          "smsggetpubkey",          &smsggetpubkey,          false,  false},
+        {"messages",          "smsgsend",               &smsgsend,               false,  false},
+        {"messages",          "smsgsendanon",           &smsgsendanon,           false,  false},
+        {"messages",          "smsginbox",              &smsginbox,              false,  false},
+        {"messages",          "smsgoutbox",             &smsgoutbox,             false,  false},
+        {"messages",          "smsgbuckets",            &smsgbuckets,            false,  false},
 };
 
 CRPCTable::CRPCTable()

--- a/src/bitcoinrpc.h
+++ b/src/bitcoinrpc.h
@@ -93,6 +93,7 @@ typedef json_spirit::Value(*rpcfn_type)(const json_spirit::Array& params, bool f
 class CRPCCommand
 {
 public:
+    std::string category;
     std::string name;
     rpcfn_type actor;
     bool okSafeMode;


### PR DESCRIPTION
Hi.

I have seen in other wallets that **help()** function output was clearer than the on of DeepOnion, so I have modified **bitcoinrpc.cpp** and **bitcoinrpc.h** and added "categories" column to **vRPCCommands** table. Now every command has its category and when **help()** command is used, at the output commands are sorted by category. As I said, in my opinion, this output is clearer than the previous one and helps to find faster the desired command. 

The idea and most of the code have been taken form https://github.com/PIVX-Project/PIVX and modified to be used on DeepOnion command line.   

See the attached image 
![screenshot from 2018-04-05 09-03-20](https://user-images.githubusercontent.com/1663141/38352701-56d1ad26-38b4-11e8-96fe-ea08e85766c3.png)
 

As you can see the categorizes are sorted alphabetically and the same with each command form each category. I have selected witch commands goes to witch category following those categories of PIVX project. Be free to change it if think that it's better.  

It has been tested on Linux wallet (Debian 9) on **DeepOinod** and **DeepOnion-qt** and works fine.

Just for your information, autocomplete too works properly. 