### PR TITLE
Tor connection status icon not updating

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3029,10 +3029,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
             return true;
         }
 
-        // record my external IP reported by peer
-        if (addrFrom.IsRoutable() && addrMe.IsRoutable())
-            addrSeenByPeer = addrMe;
-
         // Be shy and don't send version until we hear
         if (pfrom->fInbound)
             pfrom->PushVersion();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -512,6 +512,10 @@ void CNode::PushVersion()
     int64_t nTime = (fInbound ? GetAdjustedTime() : GetTime());
     CAddress addrYou = (addr.IsRoutable() && !IsProxy(addr) ? addr : CAddress(CService("0.0.0.0", 0)));
     CAddress addrMe = GetLocalAddress(&addr);
+
+    // record my external IP reported by peer
+    addrSeenByPeer = addrMe;
+
     RAND_bytes((unsigned char *)&nLocalHostNonce, sizeof(nLocalHostNonce));
     printf("send version message: version %d, blocks=%d, us=%s, them=%s, peer=%s\n", PROTOCOL_VERSION, nBestHeight, addrMe.ToString().c_str(), addrYou.ToString().c_str(), addr.ToString().c_str());
     PushMessage("version", PROTOCOL_VERSION, nLocalServices, nTime, addrYou, addrMe,


### PR DESCRIPTION
With the latest wallet the tor icon in the status bar will never update and always show "Connecting to tor network", because the tor ip is not being reported correctly. The already declared external value addrSeenByPeer will now be set directly in net.ccp where it's also defined initially. Also "IsRoutable()" would always return false for tor ip addresses as onion addresses are never valid ipv4 / v6 addresses.