### PR TITLE
Fix tor status changing to 'connecting' when nodes count updates

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -607,8 +607,7 @@ void BitcoinGUI::setNumConnections(int count)
 
     if (fTorEnabled == 1)
     {
-        labelOnionIcon->setPixmap(QIcon(":/icons/tor_inactive").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
-        labelOnionIcon->setToolTip(tr("Connecting over the Tor network"));
+        updateOnionIcon();
     }
 }
 


### PR DESCRIPTION
Currently whenever node count updates tor icon in status bar gets set back to "Connecting over Tor network". It should simply update the connection status via the proper function instead