### PR TITLE
Small gui fixes

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -257,6 +257,12 @@
            <property name="toolTip">
             <string>SOCKS version of the proxy (e.g. 5)</string>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>75</width>
+             <height>0</height>
+            </size>
+           </property>
           </widget>
          </item>
          <item>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -243,9 +243,6 @@
          <property name="text">
           <string>Using OpenSSL version</string>
          </property>
-         <property name="indent">
-          <number>10</number>
-         </property>
         </widget>
        </item>
        <item row="2" column="1">


### PR DESCRIPTION
Fixes gui issues:

- Fix misaligned 'Using openssl version' label in rpcconsole.ui
![bildschirmfoto von 2018-04-08 13-42-08](https://user-images.githubusercontent.com/12482037/38467028-c8f11844-3b32-11e8-8e4c-9d59d86149ff.png)

- Fix SOCKS version combo box too small to read value
![bildschirmfoto von 2018-04-08 13-43-05](https://user-images.githubusercontent.com/12482037/38467030-cc6c2608-3b32-11e8-9624-7ecb47e96a2a.png)