### PR TITLE
Set progressbar progress according to downloaded blocks since last startup

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -450,8 +450,8 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, SIGNAL(numConnectionsChanged(int)), this, SLOT(setNumConnections(int)));
 
-        setNumBlocks(clientModel->getNumBlocks(), clientModel->getNumBlocksOfPeers());
-        connect(clientModel, SIGNAL(numBlocksChanged(int, int)), this, SLOT(setNumBlocks(int, int)));
+        setNumBlocks(clientModel->getNumBlocks(), clientModel->getNumBlocksOfPeers(), clientModel->getNumBlocksAtStartup());
+        connect(clientModel, SIGNAL(numBlocksChanged(int, int, int)), this, SLOT(setNumBlocks(int, int, int)));
 
         // Report errors from network/worker thread
         connect(clientModel, SIGNAL(error(QString, QString, bool)), this, SLOT(error(QString, QString, bool)));
@@ -611,7 +611,7 @@ void BitcoinGUI::setNumConnections(int count)
     }
 }
 
-void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
+void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks, int nBlocksAtStartup)
 {
     // don't show / hide progress bar and its label if we have no connection to the network
     if (!clientModel || clientModel->getNumConnections() == 0)
@@ -628,15 +628,15 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks)
     if (count < nTotalBlocks)
     {
         int nRemainingBlocks = nTotalBlocks - count;
-        float nPercentageDone = count / (nTotalBlocks * 0.01f);
+        float nPercentageDone = (count - nBlocksAtStartup) / (nTotalBlocks * 0.01f) - nBlocksAtStartup;
 
         if (strStatusBarWarnings.isEmpty())
         {
             progressBarLabel->setText(tr("Synchronizing with network..."));
             progressBarLabel->setVisible(true);
             progressBar->setFormat(tr("~%n block(s) remaining", "", nRemainingBlocks));
-            progressBar->setMaximum(nTotalBlocks);
-            progressBar->setValue(count);
+            progressBar->setMaximum(nTotalBlocks - nBlocksAtStartup);
+            progressBar->setValue(count - nBlocksAtStartup);
             progressBar->setVisible(true);
         }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -628,7 +628,7 @@ void BitcoinGUI::setNumBlocks(int count, int nTotalBlocks, int nBlocksAtStartup)
     if (count < nTotalBlocks)
     {
         int nRemainingBlocks = nTotalBlocks - count;
-        float nPercentageDone = (count - nBlocksAtStartup) / (nTotalBlocks * 0.01f) - nBlocksAtStartup;
+        float nPercentageDone = (count - nBlocksAtStartup) / ((nTotalBlocks - nBlocksAtStartup) * 0.01f);
 
         if (strStatusBarWarnings.isEmpty())
         {

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -125,7 +125,7 @@ public slots:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set number of blocks shown in the UI */
-    void setNumBlocks(int count, int nTotalBlocks);
+    void setNumBlocks(int count, int nTotalBlocks, int nBlocksAtStartup);
     /** Set the encryption status as shown in the UI.
        @param[in] status            current encryption status
        @see WalletModel::EncryptionStatus

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -58,7 +58,9 @@ int ClientModel::getNumBlocks() const
 
 int ClientModel::getNumBlocksAtStartup()
 {
-    if (numBlocksAtStartup == -1) numBlocksAtStartup = getNumBlocks();
+    if (numBlocksAtStartup == -1 || numBlocksAtStartup > getNumBlocks()){
+	numBlocksAtStartup = getNumBlocks();
+    }
     return numBlocksAtStartup;
 }
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -86,13 +86,14 @@ void ClientModel::updateTimer()
     // Periodically check and update with a timer.
     int newNumBlocks = getNumBlocks();
     int newNumBlocksOfPeers = getNumBlocksOfPeers();
+    int nBlocksAtStartup = getNumBlocksAtStartup();
 
     if(cachedNumBlocks != newNumBlocks || cachedNumBlocksOfPeers != newNumBlocksOfPeers)
     {
         cachedNumBlocks = newNumBlocks;
         cachedNumBlocksOfPeers = newNumBlocksOfPeers;
 
-        emit numBlocksChanged(newNumBlocks, newNumBlocksOfPeers);
+        emit numBlocksChanged(newNumBlocks, newNumBlocksOfPeers, nBlocksAtStartup);
     }
 
     emit bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
@@ -124,7 +125,7 @@ void ClientModel::updateAlert(const QString &hash, int status)
 
     // Emit a numBlocksChanged when the status message changes,
     // so that the view recomputes and updates the status bar.
-    emit numBlocksChanged(getNumBlocks(), getNumBlocksOfPeers());
+    emit numBlocksChanged(getNumBlocks(), getNumBlocksOfPeers(), getNumBlocksAtStartup());
 }
 
 bool ClientModel::isTestNet() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -75,7 +75,7 @@ private:
 signals:
     void numConnectionsChanged(int count);
     void networkActiveChanged(bool networkActive);
-    void numBlocksChanged(int count, int countOfPeers);
+    void numBlocksChanged(int count, int countOfPeers, int nBlocksAtStartup);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
 
     //! Asynchronous error notification

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -287,7 +287,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         setNumConnections(model->getNumConnections());
         // Subscribe to information, replies, messages, errors
         connect(model, SIGNAL(numConnectionsChanged(int)), this, SLOT(setNumConnections(int)));
-        connect(model, SIGNAL(numBlocksChanged(int, int)), this, SLOT(setNumBlocks(int, int)));
+        connect(model, SIGNAL(numBlocksChanged(int, int, int)), this, SLOT(setNumBlocks(int, int, int)));
 
         updateNetworkState();
 
@@ -379,7 +379,7 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         ui->isTestNet->setChecked(model->isTestNet());
 
-        setNumBlocks(model->getNumBlocks(), model->getNumBlocksOfPeers());
+        setNumBlocks(model->getNumBlocks(), model->getNumBlocksOfPeers(), model->getNumBlocksAtStartup());
 
         //Setup autocomplete and attach it
         QStringList wordList;
@@ -483,7 +483,7 @@ void RPCConsole::updateNetworkState()
     ui->numberOfConnections->setText(connections);
 }
 
-void RPCConsole::setNumBlocks(int count, int countOfPeers)
+void RPCConsole::setNumBlocks(int count, int countOfPeers, int nBlocksAtStartup)
 {
     ui->numberOfBlocks->setText(QString::number(count));
     ui->totalBlocks->setText(QString::number(countOfPeers));

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -75,7 +75,7 @@ private slots:
     /** Set network state shown in the UI */
     void setNetworkActive(bool networkActive);
     /** Set number of blocks shown in the UI */
-    void setNumBlocks(int count, int countOfPeers);
+    void setNumBlocks(int count, int countOfPeers, int nBlocksAtStartup);
     /** Go forward or back in history */
     void browseHistory(int offset);
     /** Scroll console view to end */


### PR DESCRIPTION
With this commit the progress bar in the statusbar updates according to how many blocks are left to sync subtracted by the last block number that was already loaded previously.

I would say this makes more sense, as a user that already loaded 100% of the blockchain before and then reopens his wallet a few hours later would get a progress bar at 99% completion where the missing 1% represents the time he has to wait until the sync completion. With this method progress bar always loads from 0% to 100% evenly.

An example during sync:
![bildschirmfoto von 2018-04-08 21-32-19](https://user-images.githubusercontent.com/12482037/38471676-c993d998-3b74-11e8-84c6-43153aad3008.png)
 
When the wallet gets closed and reopened the progressbar starts back at 0% while still being at the lower remaining block count
![bildschirmfoto von 2018-04-08 21-32-53](https://user-images.githubusercontent.com/12482037/38471677-ce4db968-3b74-11e8-81d7-7b83d5f2333d.png)

