### PR TITLE
Added menu entry to open DeepOnion.conf file with the system default editor

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -338,6 +338,8 @@ void BitcoinGUI::createActions()
     encryptWalletAction = new QAction(QIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setToolTip(tr("Encrypt or decrypt wallet"));
     encryptWalletAction->setCheckable(true);
+    openConfEditorAction = new QAction(QIcon(":/icons/edit"), tr("Open configuration &file..."), this);
+    openConfEditorAction->setToolTip(tr("Open the configuration file DeepOnion.conf"));
     backupWalletAction = new QAction(QIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setToolTip(tr("Backup wallet to another location"));
     changePassphraseAction = new QAction(QIcon(":/icons/key"), tr("&Change Passphrase..."), this);
@@ -366,6 +368,9 @@ void BitcoinGUI::createActions()
     connect(lockWalletAction, SIGNAL(triggered()), this, SLOT(lockWallet()));
     connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
     connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
+    
+    rpcConsole = new RPCConsole(this);
+    connect(openConfEditorAction, SIGNAL(triggered()), rpcConsole, SLOT(showConfEditor()));
 }
 
 void BitcoinGUI::changeStyleSheet()
@@ -398,6 +403,7 @@ void BitcoinGUI::createMenuBar()
     settings->addAction(unlockWalletAction);
     settings->addAction(lockWalletAction);
     settings->addSeparator();
+    settings->addAction(openConfEditorAction);   
     settings->addAction(optionsAction);
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
@@ -540,6 +546,7 @@ void BitcoinGUI::createTrayIcon()
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
     trayIconMenu->addAction(openRPCConsoleAction);
+    trayIconMenu->addAction(openConfEditorAction);
 #ifndef Q_OS_MAC // This is built-in on Mac
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -245,7 +245,10 @@ BitcoinGUI::BitcoinGUI(QWidget *parent) : QMainWindow(parent),
 
     rpcConsole = new RPCConsole(this);
     connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(show()));
-
+    
+    // Clicking on "Open configuration file" in "Settings" menu opens DeepOnion.conf file in the system default editor
+    connect(openConfEditorAction, SIGNAL(triggered()), rpcConsole, SLOT(showConfEditor()));
+    
     // Clicking on "Verify Message" in the address book sends you to the verify message tab
     connect(addressBookPage, SIGNAL(verifyMessage(QString)), this, SLOT(gotoVerifyMessageTab(QString)));
     // Clicking on "Sign Message" in the receive coins page sends you to the sign message tab
@@ -369,8 +372,6 @@ void BitcoinGUI::createActions()
     connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
     connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
     
-    rpcConsole = new RPCConsole(this);
-    connect(openConfEditorAction, SIGNAL(triggered()), rpcConsole, SLOT(showConfEditor()));
 }
 
 void BitcoinGUI::changeStyleSheet()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -97,6 +97,7 @@ private:
     QAction *toggleHideAction;
     QAction *exportAction;
     QAction *encryptWalletAction;
+    QAction *openConfEditorAction;    
     QAction *backupWalletAction;
     QAction *changePassphraseAction;
     QAction *unlockWalletAction;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -350,6 +350,15 @@ void openDebugLogfile()
         QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathDebug.string())));
 }
 
+void openConfigfile()
+{
+    boost::filesystem::path pathConfig = GetConfigFile();
+
+    /* Open deeponion.conf with the associated application */
+    if (boost::filesystem::exists(pathConfig))
+        QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromStdString(pathConfig.string())));
+}
+
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) : QObject(parent), size_threshold(size_threshold)
 {
 }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -91,6 +91,10 @@ bool isObscured(QWidget *w);
 // Open debug.log
 void openDebugLogfile();
 
+// Open DeepOnion.conf
+void openConfigfile();
+
+
 /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
       representation if needed. This assures that Qt can word-wrap long tooltip messages.
       Tooltips longer than the provided size threshold (in characters) are wrapped.

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -787,6 +787,11 @@ void RPCConsole::unbanSelectedNode()
     clientModel->getBanTableModel()->refresh();
 }
 
+void RPCConsole::showConfEditor()
+{
+    GUIUtil::openConfigfile();
+}
+
 void RPCConsole::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -66,6 +66,8 @@ private slots:
     void showOrHideBanTableIfRequired();
     /** clear the selected node */
     void clearSelectedNode();
+    /** Open external (default) editor with DeepOnion.conf */
+    void showConfEditor();
 
   public slots:
     void clear();
@@ -90,6 +92,7 @@ private slots:
     void banSelectedNode(int bantime);
     /** Unban a selected node on the Bans tab */
     void unbanSelectedNode();
+
   signals:
     // For RPC command executor
     void stopExecutor();


### PR DESCRIPTION
Hi there

I have added a new entry in the **Settings** menu to open **DeepOnion.conf** file with the system default file editor. I think that it could be helpful when one wants to edit this file, just by clocking there the editor opens with the desired file.

I have tested it on Linux (but not in Windows or MAC) and works fine. I think that it should work properly on Windows or Mac because the piece of code open the editor is analogous to that one that opens the Debug log file with the default editor.    

![img](https://img3.picload.org/image/dawcigpl/scrn1.png)