### PR TITLE
Add menu option to enable / disable debug messages

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -210,6 +210,9 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // Read fPrintDebugLog and decide wether to start logging
+    fPrintDebugLog = optionsModel.getPrintDebugLog();
+
     QSplashScreen splash(QPixmap(GetBoolArg("-testnet") ? ":/images/splash_testnet" : ":/images/splash"), 0);
 
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min"))

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -409,6 +409,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="printDebugLog">
+         <property name="toolTip">
+          <string>If enabled DeepOnion wallet will print all debug messages to debug.log file.</string>
+         </property>
+         <property name="text">
+          <string>Print debug messages to log file</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Display">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -150,6 +150,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->displayAddresses, OptionsModel::DisplayAddresses);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
+    mapper->addMapping(ui->printDebugLog, OptionsModel::PrintDebugLog);
 }
 
 void OptionsDialog::enableApplyButton()

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -46,6 +46,7 @@ void OptionsModel::Init()
     fMinimizeToTray = settings.value("fMinimizeToTray", false).toBool();
     fMinimizeOnClose = settings.value("fMinimizeOnClose", false).toBool();
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
+    fPrintDebugLog = settings.value("fPrintDebugLog", false).toBool();
     nTransactionFee = settings.value("nTransactionFee").toLongLong();
     nReserveBalance = settings.value("nReserveBalance").toLongLong();
     language = settings.value("language", "").toString();
@@ -176,6 +177,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("language", "");
         case CoinControlFeatures:
             return QVariant(fCoinControlFeatures);
+	case PrintDebugLog:
+	    return QVariant(fPrintDebugLog);
         default:
             return QVariant();
         }
@@ -276,6 +279,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             emit coinControlFeaturesChanged(fCoinControlFeatures);
             }
             break;
+	case PrintDebugLog: {
+	    fPrintDebugLog = value.toBool();
+	    settings.setValue("fPrintDebugLog", fPrintDebugLog);
+	    }
+	    break;
         default:
             break;
         }
@@ -318,4 +326,9 @@ int OptionsModel::getDisplayUnit()
 bool OptionsModel::getDisplayAddresses()
 {
     return bDisplayAddresses;
+}
+
+bool OptionsModel::getPrintDebugLog()
+{
+    return fPrintDebugLog;
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -32,6 +32,7 @@ public:
         DetachDatabases,   // bool
         Language,          // QString
         CoinControlFeatures, // bool
+        PrintDebugLog,     // bool
         OptionIDRowCount,
     };
 
@@ -52,6 +53,7 @@ public:
     int getDisplayUnit();
     bool getDisplayAddresses();
     bool getCoinControlFeatures();
+    bool getPrintDebugLog();
     QString getLanguage() { return language; }
 
 private:
@@ -60,6 +62,7 @@ private:
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     bool fCoinControlFeatures;
+    bool fPrintDebugLog;
     QString language;
 
 signals:

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -82,6 +82,7 @@ bool fNoListen = false;
 bool fLogTimestamps = false;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
+bool fPrintDebugLog = true;
 
 // Init OpenSSL library multithreading support
 static CCriticalSection** ppmutexOpenSSL;
@@ -209,7 +210,7 @@ inline int OutputDebugStringF(const char* pszFormat, ...)
         ret = vprintf(pszFormat, arg_ptr);
         va_end(arg_ptr);
     }
-    else if (!fPrintToDebugger)
+    else if (!fPrintToDebugger && fPrintDebugLog)
     {
         // print to debug.log
 

--- a/src/util.h
+++ b/src/util.h
@@ -152,6 +152,7 @@ extern bool fTestNet;
 extern bool fNoListen;
 extern bool fLogTimestamps;
 extern bool fReopenDebugLog;
+extern bool fPrintDebugLog;
 
 void RandAddSeed();
 void RandAddSeedPerfmon();


### PR DESCRIPTION
I've added an option to enable / disable debug messages. I noticed that we have excessive logging e.g. hash of each new block, current network height, trust etc which slows down the sync process and can especially be noticed on initial sync. Debug messages are disabled by default as 95% of all users never use them and it would only negatively effect their sync time. If someone needs debug messages he needs to check the box & restart the wallet.

![bildschirmfoto von 2018-04-21 20-08-14](https://user-images.githubusercontent.com/12482037/39087333-c13aff58-459f-11e8-8b62-960c1e9590e1.png)
