### PR TITLE
Remove unused isTestnet variable

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -155,11 +155,9 @@ int main(int argc, char *argv[])
     // Application identification (must be set before OptionsModel is initialized,
     // as it is used to locate QSettings)
     app.setOrganizationName("DeepOnion");
-    //XXX app.setOrganizationDomain("");
-    bool isTestNet = false;
+
     if(GetBoolArg("-testnet")) { // Separate UI settings for testnet
         app.setApplicationName("DeepOnion-Qt-testnet");
-        isTestNet = true;
     }
     else
         app.setApplicationName("DeepOnion-Qt");


### PR DESCRIPTION
Just a very small cleanup, isTestNet is not used and also not declared as external variable so it can be removed (if necessary at a later point one can use clientModel->isTestNet()).

Testnet variable is set later as fTestNet = GetBoolArg("-testnet");