### PR TITLE
Fix address type is editable when editing receiving address label

### DIFF
--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -66,7 +66,6 @@ void EditAddressDialog::setModel(AddressTableModel *model)
     	ui->stealthCB->setText("Stealth Address (disabled)");
     }
     else {
-    	ui->stealthCB->setEnabled(true);
     	ui->stealthCB->setText("Stealth Address");
     }
 }

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -31,13 +31,13 @@ EditAddressDialog::EditAddressDialog(Mode mode, QWidget *parent) :
     case EditReceivingAddress:
         setWindowTitle(tr("Edit receiving address"));
         ui->addressEdit->setEnabled(false);
-		ui->addressEdit->setVisible(true);
-		ui->stealthCB->setEnabled(false);
-		ui->stealthCB->setVisible(true);
+        ui->addressEdit->setVisible(true);
+        ui->stealthCB->setEnabled(false);
+        ui->stealthCB->setVisible(true);
         break;
     case EditSendingAddress:
         setWindowTitle(tr("Edit sending address"));
-		ui->stealthCB->setVisible(false);
+        ui->stealthCB->setVisible(false);
         break;
     }
 


### PR DESCRIPTION
When right clicking "Edit" on any receiving address the stealth address checkbox was editable which shouldn't be the case