### PR TITLE
Fixed issue: undefined reference to qInitResources_bitcoin()

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -127,6 +127,7 @@ int main(int argc, char *argv[])
 #endif
 
     Q_INIT_RESOURCE(bitcoin);
+    Q_INIT_RESOURCE(bitcoin_locale);
     QApplication app(argc, argv);
 
     // Already apply custom stylesheets so they are already visible on the intro screen

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -1,4 +1,4 @@
-<RCC version="1.0">
+<!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/icons">
         <file alias="address-book">res/icons/address-book.png</file>
         <file alias="quit">res/icons/quit.png</file>
@@ -60,11 +60,5 @@
     </qresource>
     <qresource prefix="/movies">
         <file alias="update_spinner">res/movies/update_spinner.mng</file>
-    </qresource>
-    <qresource prefix="/translations">
-        <file alias="en">locale/bitcoin_en.qm</file>
-        <file alias="fr">locale/bitcoin_fr.qm</file>
-        <file alias="ru">locale/bitcoin_ru.qm</file>
-        <file alias="es">locale/bitcoin_es.qm</file>
     </qresource>
 </RCC>

--- a/src/qt/bitcoin_locale.qrc
+++ b/src/qt/bitcoin_locale.qrc
@@ -1,4 +1,4 @@
-<RCC version="1.0">
+<!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/translations">
         <file alias="en">locale/bitcoin_en.qm</file>
         <file alias="fr">locale/bitcoin_fr.qm</file>


### PR DESCRIPTION
Hi.

This fixes the following issues: https://github.com/deeponion/deeponion/issues/75 and https://github.com/deeponion/deeponion/issues/106

It have been tested on Linux and MAC, test that it works fine on Windows.