### PR TITLE
Fix crash of wallet when doing a clean install

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2381,15 +2381,18 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig) c
         if (GetBlockTime() < (int64_t)tx.nTime)
             return DoS(50, error("CheckBlock() : block timestamp earlier than transaction timestamp"));
 
-        // DeepOnion: check stealth tx, making sure the narration length does not exceed 24 ch, to avoid exploit
-        if(fCheckSig && ((pindexBest->nHeight >= SWITCH_BLOCK_HARD_FORK && !fTestNet) 
-        		|| (pindexBest->nHeight >= SWITCH_BLOCK_HARD_FORK_TESTNET_NARRATION_FIX && fTestNet)))
-            if(!tx.CheckStealthTxNarrSize()) 
-            {
-            	mempool.remove(tx);
-                return DoS(tx.nDoS, error("CheckBlock() : CheckStealthTxNarrSize failed"));
-            }
+        if(fCheckSig && pindexBest != NULL)
+        {
+            // DeepOnion: check stealth tx, making sure the narration length does not exceed 24 ch, to avoid exploit
+            if((pindexBest->nHeight >= SWITCH_BLOCK_HARD_FORK && !fTestNet) 
+                    || (pindexBest->nHeight >= SWITCH_BLOCK_HARD_FORK_TESTNET_NARRATION_FIX && fTestNet))
+                if(!tx.CheckStealthTxNarrSize()) 
+                {
+                    mempool.remove(tx);
+                    return DoS(tx.nDoS, error("CheckBlock() : CheckStealthTxNarrSize failed"));
+                }
         }
+    }
 
     // Check for duplicate txids. This is caught by ConnectInputs(),
     // but catching it earlier avoids a potential DoS attack:


### PR DESCRIPTION
Fix crash of wallet when doing a clean install. On initial sync pindexBest == NULL so when the wallet executes CheckBlock() for the first time it accesses a not allocated memory address and crashes