### PR TITLE
Add progress information to initial splashscreen about block verification process

### DIFF
--- a/src/init.h
+++ b/src/init.h
@@ -9,6 +9,7 @@
 #include "anonymize.h"
 
 extern CWallet* pwalletMain;
+extern CClientUIInterface uiInterface;
 extern std::string strWalletFileName;
 void StartShutdown();
 void Shutdown(void* parg);

--- a/src/txdb-leveldb.cpp
+++ b/src/txdb-leveldb.cpp
@@ -19,6 +19,7 @@
 #include "txdb.h"
 #include "util.h"
 #include "main.h"
+#include "ui_interface.h"
 
 using namespace std;
 using namespace boost;
@@ -453,6 +454,12 @@ bool CTxDB::LoadBlockIndex()
     map<pair<unsigned int, unsigned int>, CBlockIndex*> mapBlockPos;
     for (CBlockIndex* pindex = pindexBest; pindex && pindex->pprev; pindex = pindex->pprev)
     {
+        // Display verify progress on splash screen to show application
+        // activity to users, not an unresponsive screen with unknown status
+        if(nCheckDepth != 0 && nCheckDepth%100 == 0){
+            uiInterface.InitMessage("Verifying latest blocks: " + to_string(((pindexBest->nHeight - pindex->nHeight) / (nCheckDepth * 0.01f))) + "%");
+        }
+		
         if (fRequestShutdown || pindex->nHeight < nBestHeight-nCheckDepth)
             break;
         CBlock block;


### PR DESCRIPTION
Added a percentage value to the splash screen showing the status of block verification process. I would also like to add a status to the memory loading process, but I'm not sure how as the maximum block number is only known after finishing the load process.

![deep_onion](https://user-images.githubusercontent.com/12482037/40013660-70626758-57ae-11e8-85ee-ea13d6b88961.png)
