### PR TITLE
Return json objects for rpc results to be consistent

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -99,7 +99,10 @@ Value getnetworkhashps(const Array& params, bool fHelp)
                             "getnetworkhashps\n"
                             "Returns a exponential moving estimate of the current network hashrate (Mhash/s)");
     
-    return GetPoWMHashPS();
+    Object obj;
+    obj.push_back(Pair("pow_networkhashps", GetPoWMHashPS()));
+    obj.push_back(Pair("pos_networkhashps", GetPoSKernelPS()));
+    return obj;
 }
 
 Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPrintTransactionDetail)
@@ -161,7 +164,9 @@ Value getbestblockhash(const Array& params, bool fHelp)
             "getbestblockhash\n"
             "Returns the hash of the best block in the longest block chain.");
 
-    return hashBestChain.GetHex();
+    Object obj;
+    obj.push_back(Pair("bestblockhash", hashBestChain.GetHex()));
+    return obj;
 }
 
 Value getblockcount(const Array& params, bool fHelp)
@@ -171,7 +176,9 @@ Value getblockcount(const Array& params, bool fHelp)
             "getblockcount\n"
             "Returns the number of blocks in the longest block chain.");
 
-    return nBestHeight;
+    Object obj;
+    obj.push_back(Pair("blockcount", nBestHeight));
+    return obj;
 }
 
 
@@ -232,7 +239,10 @@ Value getblockhash(const Array& params, bool fHelp)
         throw runtime_error("Block number out of range.");
 
     CBlockIndex* pblockindex = FindBlockByHeight(nHeight);
-    return pblockindex->phashBlock->GetHex();
+    
+    Object obj;
+    obj.push_back(Pair("blockhash", pblockindex->phashBlock->GetHex()));
+    return obj;
 }
 
 Value getblock(const Array& params, bool fHelp)


### PR DESCRIPTION
Some results have been returned as json object, some not. I think we should be consistent and return all of them via json.