### PR TITLE
remove warning on Makefile.qt.include

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -12,7 +12,7 @@ QT_FORMS_UI = \
   qt/forms/aboutdialog.ui \
   qt/forms/addressbookpage.ui \
   qt/forms/askpassphrasedialog.ui \
-  qt/forms/blockchaindialog.ui \  
+  qt/forms/blockchaindialog.ui \
   qt/forms/coincontroldialog.ui \
   qt/forms/editaddressdialog.ui \
   qt/forms/intro.ui \


### PR DESCRIPTION
This PR removes a warning on Makefile.qt.include that appeared when this pull request was made https://github.com/deeponion/deeponion/pull/122